### PR TITLE
chore: bump `l10n_countries` to v1.1.1 and dart sdk to v3.8.1

### DIFF
--- a/packages/l10n_countries/CHANGELOG.md
+++ b/packages/l10n_countries/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.1
+
+CHORE
+
+- The Dart SDK was bumped to v3.8.1.
+- Update German and English translations.
+
 ## 1.1.0
 
 NEW FEATURES

--- a/packages/l10n_countries/pubspec.yaml
+++ b/packages/l10n_countries/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 1.1.0
+version: 1.1.1
 name: l10n_countries
 description: Provides country names translations (for 194 different locales).
 maintainer: Roman Cinis
@@ -20,7 +20,7 @@ screenshots:
 resolution: workspace
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.8.1
 
 dev_dependencies:
   _sealed_world_tests:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
+      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.5"
+    version: "8.10.1"
   change_case:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "802bd084fb82e55df091ec8ad1553a7331b61c08251eef19a508b6f3f3a9858d"
+      sha256: "4b8701e48a58f7712492c9b1f7ba0bb9d525644dd66d023b62e1fc8cdb560c8a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.1"
+    version: "1.14.0"
   crypto:
     dependency: transitive
     description:
@@ -774,10 +774,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "1b4b9e706a10294258727674a340ae0d6e64a7231980f9f9a3d12e4b42407aad"
+      sha256: "557a315b7d2a6dbb0aaaff84d857967ce6bdc96a63dc6ee2a57ce5a6ee5d3331"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.16"
+    version: "1.1.17"
   vector_math:
     dependency: transitive
     description:
@@ -851,5 +851,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.8.1 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
<!--

  Thanks for contributing!

  Please describe your changes below, and provide a general summary in the title.

-->

## Description

<!--- Please describe your changes in detail and link related issue(s) -->

## Type of Change

<!--- Please put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] 🧪 Tests
- [x] 📝 Documentation
- [ ] ⚙️ CI/CD or GitHub Workflow configuration change
- [ ] 📦 Dependencies update

## Checks

Please look at the following checklist to ensure that your PR can be accepted quickly:

<!--- Please put an `x` in all the boxes that apply: -->

- [ ] Data comes from open-source resources with the MIT License (if presented).
- [ ] New code is documented and the data source is referenced (if presented).
- [ ] Existing tests are up to date with these changes.
- [ ] New code is fully tested (if presented).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package version to 1.1.1 and increased Dart SDK requirement to 3.8.1.

- **Documentation**
  - Added a changelog entry for the new release.

- **New Features**
  - Improved German and English translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->