### PR TITLE
chore: bump `sealed_countries` to v2.7.0

### DIFF
--- a/packages/sealed_countries/CHANGELOG.md
+++ b/packages/sealed_countries/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 2.7.0
+
+NEW FEATURES
+
+- Adds support for XCG (Caribbean Guilder) and ZWG (Zimbabwean Gold) currencies with translations (across 100+ locales each).
+- Deprecates `ANG`, `BGN`, and `ZWL` currencies with appropriate migration paths.
+
+FIX
+
+- Corrected Slovak country name for `CIV` to "Pobrežie Slonoviny".
+- Corrected English currency name for `KGS` to "Kyrgyzstani Som".
+- Corrected English currency name for `GYD` to "Guyanese Dollar".
+
+DOCUMENTATION
+
+- Improved documentation in README.
+
+CHORE
+
+- The Dart SDK was bumped to v3.9.2.
+
 ## 2.6.0
 
 FIX

--- a/packages/sealed_countries/lib/src/data/official_world_countries.data.dart
+++ b/packages/sealed_countries/lib/src/data/official_world_countries.data.dart
@@ -14513,6 +14513,7 @@ class CountrySxm extends WorldCountry {
         timezones: const ["UTC-04:00"],
         hasCoatOfArms: false,
       );
+  @override
   // ignore: deprecated_member_use, it's TODO!
   List<FiatCurrency> get currencies => const [FiatXcg(), FiatAng()];
   @override

--- a/packages/sealed_countries/pubspec.yaml
+++ b/packages/sealed_countries/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 2.6.0
+version: 2.7.0
 name: sealed_countries
 description: Provides data for world countries in the form of sealed classes.
 maintainer: Roman Cinis
@@ -25,8 +25,8 @@ environment:
   sdk: ^3.9.2
 
 dependencies:
-  l10n_countries: ^1.2.0
-  sealed_currencies: ^2.3.0
+  l10n_countries: ^1.3.0
+  sealed_currencies: ^2.4.0
 
 dev_dependencies:
   _sealed_world_tests:


### PR DESCRIPTION
<!--

  Thanks for contributing!

  Please describe your changes below, and provide a general summary in the title.

-->

## Description

<!--- Please describe your changes in detail and link related issue(s) -->

## Type of Change

<!--- Please put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] 🧪 Tests
- [x] 📝 Documentation
- [ ] ⚙️ CI/CD or GitHub Workflow configuration change
- [x] 📦 Dependencies update

## Checks

Please look at the following checklist to ensure that your PR can be accepted quickly:

<!--- Please put an `x` in all the boxes that apply: -->

- [x] Data comes from open-source resources with the MIT License (if presented).
- [x] New code is documented and the data source is referenced (if presented).
- [x] Existing tests are up to date with these changes.
- [x] New code is fully tested (if presented).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for XCG and ZWG currencies with translations across 100+ locales.
- Deprecations
  - Marked ANG, BGN, and ZWL as deprecated with migration guidance.
- Bug Fixes
  - Corrected Slovak name for Côte d’Ivoire (CIV).
  - Fixed English currency names for KGS (“Kyrgyzstani Som”) and GYD (“Guyanese Dollar”).
- Documentation
  - Improved README.
- Chores
  - Released version 2.7.0; updated Dart SDK to 3.9.2 and refreshed dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->