### PR TITLE
fix: fix dual flags decorations and move forward with deeply-immutable classes

### DIFF
--- a/.github/workflows/config/spell-check/other_dictionary.txt
+++ b/.github/workflows/config/spell-check/other_dictionary.txt
@@ -58,9 +58,11 @@ slovenská
 staaten
 svizra
 svizzera
+taeguk
 taegukgi
 tcheco
 tham
+tokelau
 unidos
 unoff
 vereinigte

--- a/packages/_sealed_world_tests/lib/tests/advanced_tests.dart
+++ b/packages/_sealed_world_tests/lib/tests/advanced_tests.dart
@@ -61,7 +61,7 @@ void randomElementTest<T extends Object>(
 /// Returns a random item from the provided [iterable].
 @visibleForTesting
 T randomIterableItem<T extends Object>(Iterable<T> iterable) =>
-    iterable.elementAt(Random().nextInt(iterable.length));
+    iterable.elementAt(Random.secure().nextInt(iterable.length));
 
 /// Runs a test that should throw an assertion error during instance creation.
 @isTest

--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -241,6 +241,7 @@ dart_code_metrics:
     - prefer-explicit-parameter-names: false # This will be dev. defined.
     - prefer-prefixed-global-constants: false # This will be a breaking change.
     - prefer-test-matchers: false # Matter of style + introduces coupling in tests.
+    - prefer-private-named-parameters: false # Not updated to the Dart 3.12 everywhere yet.
 
     # Enabled:
     - avoid-accessing-collections-by-constant-index: true
@@ -272,6 +273,7 @@ dart_code_metrics:
     - avoid-duplicate-cascades: true
     - avoid-duplicate-constant-values: true
     - avoid-duplicate-exports: true
+    - avoid-duplicate-factories: true
     - avoid-duplicate-initializers: true
     - avoid-duplicate-map-keys: true
     - avoid-duplicate-mixins: true
@@ -352,6 +354,7 @@ dart_code_metrics:
     - avoid-returning-void: true
     - avoid-self-assignment: true
     - avoid-self-compare: true
+    - avoid-sensitive-query-params: true
     - avoid-shadowed-extension-methods: true
     - avoid-shadowing: true
     - avoid-similar-names: true
@@ -370,6 +373,7 @@ dart_code_metrics:
     - avoid-uncaught-future-errors: true
     - avoid-unconditional-break: true
     - avoid-unknown-pragma: true
+    - avoid-unmodified-loop-condition: true
     - avoid-unnecessary-block: true
     - avoid-unnecessary-call: true
     - avoid-unnecessary-collections: true
@@ -381,6 +385,7 @@ dart_code_metrics:
     - avoid-unnecessary-enum-arguments: true
     - avoid-unnecessary-enum-prefix: true
     - avoid-unnecessary-extends: true
+    - avoid-unnecessary-factory: true
     - avoid-unnecessary-futures: true
     - avoid-unnecessary-getter: true
     - avoid-unnecessary-if: true
@@ -484,6 +489,7 @@ dart_code_metrics:
     - prefer-for-in: true
     - prefer-getter-over-method: true
     - prefer-immediate-return: true
+    - prefer-initializing-formals: true
     - prefer-iterable-of: true
     - prefer-last: true
     - prefer-moving-to-variable: true
@@ -496,6 +502,7 @@ dart_code_metrics:
     - prefer-private-extension-type-field: true
     - prefer-public-exception-classes: true
     - prefer-pushing-conditional-expressions: true
+    - prefer-random-secure: true
     - prefer-redirecting-superclass-constructor: true
     - prefer-return-await: true
     - prefer-returning-condition: true

--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -521,7 +521,7 @@ dart_code_metrics:
     - prefer-visible-for-testing-on-members: true
     - prefer-wildcard-pattern: true
     - record-fields-ordering: true
-    - require-atomic-async-update: true
+    - require-atomic-async-updates: true
     - unnecessary-trailing-comma: true
     - use-existing-destructuring: true
     - use-existing-variable: true

--- a/packages/flutter_analysis_options.yaml
+++ b/packages/flutter_analysis_options.yaml
@@ -44,6 +44,8 @@ dart_code_metrics:
     - avoid-unnecessary-overrides-in-state: true
     - avoid-unnecessary-setstate: true
     - avoid-unnecessary-stateful-widgets: true
+    - avoid-unrestricted-javascript: true
+    - avoid-unrestricted-navigation: true
     - avoid-wrapping-in-padding: true
     - check-for-equals-in-render-object-setters: true
     - consistent-update-render-object: true

--- a/packages/sealed_countries/CHANGELOG.md
+++ b/packages/sealed_countries/CHANGELOG.md
@@ -3,7 +3,7 @@
 NEW FEATURES
 
 - Added `@pragma("vm:deeply-immutable")` optimization to `Capital`, `CapitalInfo`, `Gini`, `LatLng`, `Maps`, and `PostalCode` classes.
-- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making it `final` in the next major version.
+- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them `final` in the next major version.
 
 ## 3.2.0
 

--- a/packages/sealed_countries/CHANGELOG.md
+++ b/packages/sealed_countries/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0
+
+NEW FEATURES
+
+- Added `@pragma("vm:deeply-immutable")` optimization to `Capital`, `CapitalInfo`, `Gini`, `LatLng`, `Maps`, and `PostalCode` classes.
+- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making it `final` in the next major version.
+
 ## 3.2.0
 
 NEW FEATURES

--- a/packages/sealed_countries/lib/src/model/country/submodels/capital.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/capital.dart
@@ -20,6 +20,7 @@ import "../../../helpers/extensions/country_submodels/capital_extension.dart";
 // Read more about the world's capitals
 // https://en.wikipedia.org/wiki/List_of_countries_with_multiple_capitals
 // Reference (Wikipedia).
+@pragma("vm:deeply-immutable")
 final class Capital implements JsonEncodable<Capital> {
   /// Creates a new [Capital] object with the given name and optional de jure
   /// and third values.

--- a/packages/sealed_countries/lib/src/model/country/submodels/capital.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/capital.dart
@@ -24,15 +24,14 @@ final class Capital implements JsonEncodable<Capital> {
   /// Creates a new [Capital] object with the given name and optional de jure
   /// and third values.
   ///
-  /// The [name] parameter must not be empty.
-  const Capital(String name, {this.deJure, this.third})
+  /// The [deFacto] parameter must not be empty.
+  const Capital(this.deFacto, {this.deJure, this.third})
     : assert(third == null || third.length > 0, "`third` should not be empty!"),
-      assert(name.length > 0, "`name` of capital should not be empty!"),
+      assert(deFacto.length > 0, "`deFacto` capital should not be empty!"),
       assert(
         deJure == null || deJure.length > 0,
         "`deJure` should not be empty!",
-      ),
-      deFacto = name;
+      );
 
   /// The de facto name of this capital.
   final String deFacto;

--- a/packages/sealed_countries/lib/src/model/country/submodels/capital.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/capital.dart
@@ -22,8 +22,8 @@ import "../../../helpers/extensions/country_submodels/capital_extension.dart";
 // Reference (Wikipedia).
 @pragma("vm:deeply-immutable")
 final class Capital implements JsonEncodable<Capital> {
-  /// Creates a new [Capital] object with the given name and optional de jure
-  /// and third values.
+  /// Creates a new [Capital] object with the given de facto name and optional
+  /// de jure and third values.
   ///
   /// The [deFacto] parameter must not be empty.
   const Capital(this.deFacto, {this.deJure, this.third})

--- a/packages/sealed_countries/lib/src/model/country/submodels/capital_info.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/capital_info.dart
@@ -20,6 +20,7 @@ import "lat_lng.dart";
 /// print(capitalInfo.capital); // Prints: Capital("Ramallah")
 /// print(capitalInfo.latLng); // Prints: LatLng(latitude: 31.9, longitude: 35.2)
 /// ```
+@pragma("vm:deeply-immutable")
 final class CapitalInfo implements JsonEncodable<CapitalInfo> {
   /// Creates a new [CapitalInfo] object with the given capital
   /// and location values.

--- a/packages/sealed_countries/lib/src/model/country/submodels/car.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/car.dart
@@ -17,6 +17,7 @@ import "../../../helpers/extensions/country_submodels/car_extension.dart";
 /// print(car.sign); // Prints: "NEP"
 /// print(car.isRightSide); // Prints: false
 /// ```
+@pragma("vm:deeply-immutable")
 final class Car implements JsonEncodable<Car> {
   /// Creates a new [Car] object with the given sign and side values.
   ///

--- a/packages/sealed_countries/lib/src/model/country/submodels/gini.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/gini.dart
@@ -18,6 +18,7 @@ import "../../../helpers/extensions/country_submodels/gini_extension.dart";
 /// print(gini.year); // Prints: 2020
 /// print(gini.coefficient); // Prints: 32.0
 /// ```
+@pragma("vm:deeply-immutable")
 final class Gini implements JsonEncodable<Gini> {
   /// Creates a new [Gini] object with the given year and coefficient.
   ///

--- a/packages/sealed_countries/lib/src/model/country/submodels/lat_lng.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/lat_lng.dart
@@ -16,6 +16,7 @@ import "../../../helpers/extensions/country_submodels/lat_lng_extension.dart";
 /// print(point.latitude); // Prints: 37.7749
 /// print(point.longitude); // Prints: -122.4194
 /// ```
+@pragma("vm:deeply-immutable")
 final class LatLng implements JsonEncodable<LatLng> {
   /// Creates a new [LatLng] object with the given [latitude] and [longitude].
   const LatLng(this.latitude, this.longitude);

--- a/packages/sealed_countries/lib/src/model/country/submodels/maps.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/maps.dart
@@ -15,6 +15,7 @@ import "../../../helpers/extensions/country_submodels/maps_extension.dart";
 /// print(maps.googleMapsUrl); // Output: "https://goo.gl/maps/abcdefg"
 /// print(maps.openStreetMapsUrl); // Output: "https://www.openstreetmap.org/123456789"
 /// ```
+@pragma("vm:deeply-immutable")
 final class Maps implements JsonEncodable<Maps> {
   /// Creates a new [Maps] object with the given Google Maps and OpenStreetMap
   /// IDs.

--- a/packages/sealed_countries/lib/src/model/country/submodels/postal_code.dart
+++ b/packages/sealed_countries/lib/src/model/country/submodels/postal_code.dart
@@ -18,6 +18,7 @@ import "../../../helpers/extensions/country_submodels/postal_code_extension.dart
 /// print(postalCode.format); // Prints: "#####-####"
 /// print(postalCode.regExpPattern); // Prints: "^(\\d{5}(-\\d{4})?)$"
 /// ```
+@pragma("vm:deeply-immutable")
 final class PostalCode implements JsonEncodable<PostalCode> {
   /// Creates a new [PostalCode] object with the given format and regular
   /// expression pattern.

--- a/packages/sealed_countries/lib/src/model/geo/region.dart
+++ b/packages/sealed_countries/lib/src/model/geo/region.dart
@@ -17,10 +17,15 @@ import "package:sealed_currencies/sealed_currencies.dart";
 /// print(city.name); // Prints: "Warsaw"
 /// ```
 /// Base type shared by continent and subregion models.
+@Deprecated.subclass(
+  "This class will be marked as `final` in the next major version to support "
+  "deep immutability optimizations. Do not extend or implement this class.",
+)
 class Region implements Named<String> {
   /// Creates a new [Region] object with the given name.
   ///
   /// The [name] parameter is required and must not be empty.
+  // ignore: deprecated_consistency, constructor cannot be annotated with it.
   const Region({required this.name});
 
   /// The name of the region.

--- a/packages/sealed_countries/lib/src/model/geo/submodels/continent.dart
+++ b/packages/sealed_countries/lib/src/model/geo/submodels/continent.dart
@@ -28,6 +28,7 @@ part "../../../data/geo/continents.data.dart";
 /// final unknown = Continent.maybeFromValue<int>(42);
 /// print(unknown); // Prints: null
 /// ```
+// ignore: deprecated_subclass, it's TODO to address in the next major version.
 sealed class Continent extends Region {
   /// Creates a new [Continent] object with the given name.
   ///

--- a/packages/sealed_countries/lib/src/model/geo/submodels/subregion.dart
+++ b/packages/sealed_countries/lib/src/model/geo/submodels/subregion.dart
@@ -10,6 +10,7 @@ part "../../../data/geo/continental_sections.data.dart";
 /// A [SubRegion] describes geographical areas such as "Central America" or
 /// "Western Europe". Each subregion belongs to a single [continent] and is
 /// modeled as an immutable value object.
+// ignore: deprecated_subclass, it's TODO to address in the next major version.
 sealed class SubRegion extends Region {
   /// Creates a new [SubRegion] with the provided [name] and [continent].
   const SubRegion(this.continent, {required super.name});

--- a/packages/sealed_countries/pubspec.yaml
+++ b/packages/sealed_countries/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 3.2.0
+version: 3.3.0
 name: sealed_countries
 description: Provides data for world countries in the form of sealed classes.
 maintainer: Roman Cinis

--- a/packages/sealed_currencies/CHANGELOG.md
+++ b/packages/sealed_currencies/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.0
+
+NEW FEATURES
+
+- Deprecated sub-classing `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them as `final` in the next major version to support deep immutability.
+
 ## 3.2.0
 
 NEW FEATURES

--- a/packages/sealed_currencies/CHANGELOG.md
+++ b/packages/sealed_currencies/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 NEW FEATURES
 
-- Deprecated sub-classing `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them as `final` in the next major version to support deep immutability.
+- Deprecated sub-classing `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them `final` in the next major version to support deep immutability.
 
 ## 3.2.0
 

--- a/packages/sealed_currencies/pubspec.yaml
+++ b/packages/sealed_currencies/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 3.2.0
+version: 3.3.0
 name: sealed_currencies
 description: Provides data for world currencies in the form of sealed classes.
 maintainer: Roman Cinis

--- a/packages/sealed_languages/CHANGELOG.md
+++ b/packages/sealed_languages/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.0
+
+NEW FEATURES
+
+- Deprecated sub-classing `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them as `final` in the next major version to support deep immutability.
+
 ## 3.2.0
 
 NEW FEATURES

--- a/packages/sealed_languages/CHANGELOG.md
+++ b/packages/sealed_languages/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 NEW FEATURES
 
-- Deprecated sub-classing `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them as `final` in the next major version to support deep immutability.
+- Deprecated sub-classing `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them `final` in the next major version to support deep immutability.
 
 ## 3.2.0
 

--- a/packages/sealed_languages/lib/src/model/language_family/language_family.dart
+++ b/packages/sealed_languages/lib/src/model/language_family/language_family.dart
@@ -4,11 +4,16 @@ import "../../interfaces/named.dart";
 ///
 /// A language family is a group of languages that have a common ancestor or are
 /// related in some other way.
+@Deprecated.subclass(
+  "This class will be marked as `final` in the next major version to support "
+  "deep immutability optimizations. Do not extend or implement this class.",
+)
 class LanguageFamily implements Named<String> {
   /// Creates a new instance of the [LanguageFamily] class.
   ///
   /// The [name] parameter is required and should be a non-empty string
   /// representing the name of the language family.
+  // ignore: deprecated_consistency, constructor cannot be annotated with it.
   const LanguageFamily({required this.name})
     : assert(name.length > 0, "`name` should not be empty!");
 

--- a/packages/sealed_languages/lib/src/model/language_family/submodels/natural_language_family.dart
+++ b/packages/sealed_languages/lib/src/model/language_family/submodels/natural_language_family.dart
@@ -12,6 +12,7 @@ part "../../../data/natural_language_families.data.dart";
 /// families include the Indo-European family (which includes languages like
 /// English, Spanish, French, and German) and the Sino-Tibetan family (which
 /// includes languages like Mandarin and Tibetan).
+// ignore: deprecated_subclass, it's TODO to address in the next major version.
 sealed class NaturalLanguageFamily extends LanguageFamily {
   /// Creates a new instance of the [NaturalLanguageFamily] class.
   ///

--- a/packages/sealed_languages/lib/src/model/script/submodels/script.dart
+++ b/packages/sealed_languages/lib/src/model/script/submodels/script.dart
@@ -224,6 +224,7 @@ part "../../../data/scripts/zyyy.data.dart";
 part "../../../data/scripts/zzzz.data.dart";
 
 /// A sealed class that represents a script used in writing systems.
+// ignore: deprecated_subclass, it's TODO to address in the next major version.
 sealed class Script extends WritingSystem
     implements
         IsoStandardized<String>,

--- a/packages/sealed_languages/lib/src/model/script/writing_system.dart
+++ b/packages/sealed_languages/lib/src/model/script/writing_system.dart
@@ -5,11 +5,16 @@ import "../../interfaces/named.dart";
 /// A writing system is a set of symbols used to represent the sounds of a
 /// language. Examples of writing systems include the Latin alphabet, the
 /// Cyrillic alphabet, the Chinese script, etc.
+@Deprecated.subclass(
+  "This class will be marked as `final` in the next major version to support "
+  "deep immutability optimizations. Do not extend or implement this class.",
+)
 class WritingSystem implements Named<String> {
   /// Creates a new instance of [WritingSystem] with the specified name.
   ///
   /// The [name] parameter is a non-empty string that represents the name of
   /// the writing system.
+  // ignore: deprecated_consistency, constructor cannot be annotated with it.
   const WritingSystem({required this.name})
     : assert(name.length > 0, "`name` should not be empty!");
 

--- a/packages/sealed_languages/pubspec.yaml
+++ b/packages/sealed_languages/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 3.2.0
+version: 3.3.0
 name: sealed_languages
 description: Provides data for world languages in the form of sealed classes.
 maintainer: Roman Cinis

--- a/packages/world_countries/CHANGELOG.md
+++ b/packages/world_countries/CHANGELOG.md
@@ -7,7 +7,7 @@ FIX
 NEW FEATURES
 
 - Added `@pragma("vm:deeply-immutable")` optimization to `Capital`, `CapitalInfo`, `Gini`, `LatLng`, `Maps`, and `PostalCode` classes.
-- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making it `final` in the next major version.
+- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them `final` in the next major version.
 
 ## 4.3.0
 

--- a/packages/world_countries/CHANGELOG.md
+++ b/packages/world_countries/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 4.4.0
+
+FIX
+
+- Fixed an issue where the decoration (like border radius) provided to `DualFlag` was only applied to the background flag and not the foreground flag. Now both flags in `DualFlag` correctly receive the decoration.
+
+NEW FEATURES
+
+- Added `@pragma("vm:deeply-immutable")` optimization to `Capital`, `CapitalInfo`, `Gini`, `LatLng`, `Maps`, and `PostalCode` classes.
+- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making it `final` in the next major version.
+
 ## 4.3.0
 
 NEW FEATURES

--- a/packages/world_countries/analysis_options.yaml
+++ b/packages/world_countries/analysis_options.yaml
@@ -1,5 +1,8 @@
 include: ../flutter_analysis_options.yaml
 
+dart_code_metrics:
+  - prefer-private-named-parameters: true
+
 linter:
   rules:
     unsafe_variance: false # Mostly inherited callbacks.

--- a/packages/world_countries/example/pubspec.yaml
+++ b/packages/world_countries/example/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.12.0
-  flutter: ^3.44.0
+  sdk: ^3.12.2
+  flutter: ^3.44.2
 
 dependencies:
   flutter:

--- a/packages/world_countries/example/pubspec.yaml
+++ b/packages/world_countries/example/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 4.3.0
+version: 4.4.0
 name: world_countries_example
 description: A world_countries example application.
 publish_to: none

--- a/packages/world_countries/pubspec.yaml
+++ b/packages/world_countries/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 4.3.0
+version: 4.4.0
 name: world_countries
 description: Sealed world data in form of Flutter widgets (country, phone, currency pickers, etc.).
 maintainer: Roman Cinis

--- a/packages/world_flags/CHANGELOG.md
+++ b/packages/world_flags/CHANGELOG.md
@@ -7,7 +7,7 @@ FIX
 NEW FEATURES
 
 - Added `@pragma("vm:deeply-immutable")` optimization to `Capital`, `CapitalInfo`, `Gini`, `LatLng`, `Maps`, and `PostalCode` classes.
-- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making it `final` in the next major version.
+- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them `final` in the next major version.
 
 ## 3.2.0
 

--- a/packages/world_flags/CHANGELOG.md
+++ b/packages/world_flags/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.3.0
+
+FIX
+
+- Fixed an issue where the decoration (like border radius) provided to `DualFlag` was only applied to the background flag and not the foreground flag. Now both flags in `DualFlag` correctly receive the decoration.
+
+NEW FEATURES
+
+- Added `@pragma("vm:deeply-immutable")` optimization to `Capital`, `CapitalInfo`, `Gini`, `LatLng`, `Maps`, and `PostalCode` classes.
+- Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making it `final` in the next major version.
+
 ## 3.2.0
 
 NEW FEATURES

--- a/packages/world_flags/CHANGELOG.md
+++ b/packages/world_flags/CHANGELOG.md
@@ -9,6 +9,10 @@ NEW FEATURES
 - Added `@pragma("vm:deeply-immutable")` optimization to `Capital`, `CapitalInfo`, `Gini`, `LatLng`, `Maps`, and `PostalCode` classes.
 - Deprecated sub-classing `Region`, `LanguageFamily` and `WritingSystem` via `@Deprecated.subclass(...)` to prepare for making them `final` in the next major version.
 
+CHORE
+
+- The Dart SDK was bumped to v3.12.0.
+
 ## 3.2.0
 
 NEW FEATURES

--- a/packages/world_flags/example/pubspec.yaml
+++ b/packages/world_flags/example/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 3.2.0
+version: 3.3.0
 name: world_flags_example
 description: A world_flags package example application.
 publish_to: none
@@ -6,7 +6,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.12.0
+  sdk: ^3.12.2
 
 dependencies:
   flutter:

--- a/packages/world_flags/lib/src/debug/iso_diagnostics_property.dart
+++ b/packages/world_flags/lib/src/debug/iso_diagnostics_property.dart
@@ -21,12 +21,12 @@ class IsoDiagnosticsProperty<Iso extends IsoStandardized>
   ///
   /// The [name] parameter is used to identify the property in diagnostic
   /// output.
-  /// The [iso] parameter is the [IsoStandardized] object to be displayed.
+  /// The [_iso] parameter is the [IsoStandardized] object to be displayed.
   ///
   /// The remaining parameters are optional and can be used to customize
   /// the behavior of the property.
   IsoDiagnosticsProperty(
-    Iso? iso, {
+    this._iso, {
     String additionalData = "",
     super.allowNameWrap,
     super.allowWrap,
@@ -40,13 +40,12 @@ class IsoDiagnosticsProperty<Iso extends IsoStandardized>
     super.showSeparator,
     super.style,
   }) : _data = additionalData,
-       _iso = iso,
        super(
-         iso?.runtimeType.toString(),
-         iso,
-         description: _toString(iso, additionalData),
-         tooltip: "ISO ${iso.runtimeType} object",
-         ifNull: "${iso.runtimeType} is not provided",
+         _iso?.runtimeType.toString(),
+         _iso,
+         description: _toString(_iso, additionalData),
+         tooltip: "ISO ${_iso.runtimeType} object",
+         ifNull: "${_iso.runtimeType} is not provided",
        );
 
   final String _data;

--- a/packages/world_flags/lib/src/ui/flags/iso/dual_flag.dart
+++ b/packages/world_flags/lib/src/ui/flags/iso/dual_flag.dart
@@ -91,7 +91,13 @@ class DualFlag<T extends IsoStandardized, F extends BasicFlag>
                 child: ClipPath(
                   clipBehavior: clipBehavior,
                   clipper: DualFlagClipper(splitAngle),
-                  child: foreground,
+                  child: foreground?.copyWith(
+                    aspectRatio: aspectRatio,
+                    decoration: decoration,
+                    decorationPosition: decorationPosition,
+                    padding: EdgeInsets.zero,
+                    child: child,
+                  ),
                 ),
               ),
             );

--- a/packages/world_flags/lib/src/ui/painters/basic/custom_elements_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/basic/custom_elements_painter.dart
@@ -19,7 +19,7 @@ abstract base class CustomElementsPainter<T extends FlagParentBounds>
   ///
   /// - [properties]: The properties of the elements to be painted.
   /// - [aspectRatio]: The aspect ratio of the flag.
-  const CustomElementsPainter(super.properties, super.aspectRatio);
+  const CustomElementsPainter(super._properties, super.aspectRatio);
 
   /// The original aspect ratio of the flag.
   ///

--- a/packages/world_flags/lib/src/ui/painters/basic/elements_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/basic/elements_painter.dart
@@ -24,13 +24,12 @@ abstract base class ElementsPainter extends CustomPainter {
   /// - [properties]: The properties of the elements to be painted. Must contain
   /// at least one element.
   /// - [aspectRatio]: The aspect ratio of the flag.
-  const ElementsPainter(ElementsProps? properties, this.aspectRatio)
+  const ElementsPainter(this._properties, this.aspectRatio)
     : assert(aspectRatio > 0, "`aspectRatio` must be greater than 0"),
       assert(
-        properties != null && properties.length > 0,
-        "`properties` must contain at least one element.",
-      ),
-      _properties = properties;
+        _properties != null && _properties.length > 0,
+        "`_properties` must contain at least one element.",
+      );
 
   /// The aspect ratio of the flag.
   final double aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/common/diagonal_line_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/common/diagonal_line_painter.dart
@@ -12,7 +12,7 @@ import "../basic/elements_painter.dart";
 final class DiagonalLinePainter extends ElementsPainter {
   /// Creates a [DiagonalLinePainter] with the given properties
   /// and aspect ratio.
-  const DiagonalLinePainter(super.properties, super.aspectRatio);
+  const DiagonalLinePainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/common/ellipse_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/common/ellipse_painter.dart
@@ -9,7 +9,7 @@ import "../basic/elements_painter.dart";
 /// ellipses based on the specified properties.
 final class EllipsePainter extends ElementsPainter {
   /// Creates an [EllipsePainter] with the given properties and aspect ratio.
-  const EllipsePainter(super.properties, super.aspectRatio);
+  const EllipsePainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/common/moon_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/common/moon_painter.dart
@@ -10,7 +10,7 @@ import "../basic/elements_painter.dart";
 /// moon shapes based on the specified properties.
 final class MoonPainter extends ElementsPainter {
   /// Creates a [MoonPainter] with the given properties and aspect ratio.
-  const MoonPainter(super.properties, super.aspectRatio);
+  const MoonPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/common/rectangle_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/common/rectangle_painter.dart
@@ -10,7 +10,7 @@ import "../basic/elements_painter.dart";
 /// rectangles based on the specified properties.
 final class RectanglePainter extends ElementsPainter {
   /// Creates a [RectanglePainter] with the given properties and aspect ratio.
-  const RectanglePainter(super.properties, super.aspectRatio);
+  const RectanglePainter(super._properties, super.aspectRatio);
 
   @override
   Paint paintCreator([Color? color]) =>

--- a/packages/world_flags/lib/src/ui/painters/common/star_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/common/star_painter.dart
@@ -14,7 +14,7 @@ import "../basic/elements_painter.dart";
 /// properties.
 final class StarPainter extends ElementsPainter {
   /// Creates a [StarPainter] with the given properties and aspect ratio.
-  const StarPainter(super.properties, super.aspectRatio);
+  const StarPainter(super._properties, super.aspectRatio);
   static const _startRadians = pi / 2;
   static const _radiansMultiplier = pi / 180;
 

--- a/packages/world_flags/lib/src/ui/painters/common/triangle_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/common/triangle_painter.dart
@@ -9,7 +9,7 @@ import "../basic/elements_painter.dart";
 /// triangles in various orientations based on the specified properties.
 final class TrianglePainter extends ElementsPainter {
   /// Creates a [TrianglePainter] with the given properties and aspect ratio.
-  const TrianglePainter(super.properties, super.aspectRatio);
+  const TrianglePainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) =>

--- a/packages/world_flags/lib/src/ui/painters/custom/ago_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/ago_painter.dart
@@ -10,7 +10,7 @@ import "../common/star_painter.dart";
 /// Painter for the Angola flag.
 final class AgoPainter extends CustomElementsPainter {
   /// Creates a new instance of [AgoPainter].
-  const AgoPainter(super.properties, super.aspectRatio);
+  const AgoPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagAgoProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/alb_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/alb_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Albania flag.
 final class AlbPainter extends CustomElementsPainter {
   /// Creates a new instance of [AlbPainter].
-  const AlbPainter(super.properties, super.aspectRatio);
+  const AlbPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagAlbProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/almond_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/almond_painter.dart
@@ -11,11 +11,11 @@ import "../multi_element_painter.dart";
 /// Painter for the Guam and Eswatini flag.
 final class AlmondPainter extends CustomElementsPainter {
   /// Creates a new instance of [AlmondPainter] for Guam flag.
-  const AlmondPainter.gum(super.properties, super.aspectRatio)
+  const AlmondPainter.gum(super._properties, super.aspectRatio)
     : _isVertical = true;
 
   /// Creates a new instance of [AlmondPainter] for Eswatini flag.
-  const AlmondPainter.swz(super.properties, super.aspectRatio)
+  const AlmondPainter.swz(super._properties, super.aspectRatio)
     : _isVertical = false;
 
   final bool _isVertical;
@@ -30,7 +30,7 @@ final class AlmondPainter extends CustomElementsPainter {
     /// TODO? Refactor with .save() and .restore() methods.
     MultiElementPainter(
       List.unmodifiable(properties.skip(1)),
-      aspectRatio, // ignore: unnecessary-trailing-comma, new dart format.
+      aspectRatio,
     ).paint(canvas, size);
 
     final center = calculateCenter(size);

--- a/packages/world_flags/lib/src/ui/painters/custom/ata_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/ata_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Antarctica flag.
 final class AtaPainter extends CustomElementsPainter {
   /// Creates a new instance of [AtaPainter].
-  const AtaPainter(super.properties, super.aspectRatio);
+  const AtaPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagAtaProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/atf_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/atf_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the French Southern and Antarctic Lands flag.
 final class AtfPainter extends MultiElementPainter {
   /// Creates a new instance of [AtfPainter].
-  const AtfPainter(super.properties, super.aspectRatio);
+  const AtfPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagAtfProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/atg_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/atg_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Antigua and Barbuda flag.
 final class AtgPainter extends MultiElementPainter {
   /// Creates a new instance of [AtgPainter].
-  const AtgPainter(super.properties, super.aspectRatio);
+  const AtgPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/blr_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/blr_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Belarus flag.
 final class BlrPainter extends CustomElementsPainter {
   /// Creates a new instance of [BlrPainter].
-  const BlrPainter(super.properties, super.aspectRatio);
+  const BlrPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagBlrProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/bra_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/bra_painter.dart
@@ -5,7 +5,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Brazil flag.
 final class BraPainter extends MultiElementPainter {
   /// Creates a new instance of [BraPainter].
-  const BraPainter(super.properties, super.aspectRatio);
+  const BraPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagBraProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/brb_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/brb_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Barbados flag.
 final class BrbPainter extends CustomElementsPainter {
   /// Creates a new instance of [BrbPainter].
-  const BrbPainter(super.properties, super.aspectRatio);
+  const BrbPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagBrbProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/brn_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/brn_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Brunei flag.
 final class BrnPainter extends MultiElementPainter {
   /// Creates a new instance of [BrnPainter].
-  const BrnPainter(super.properties, super.aspectRatio);
+  const BrnPainter(super._properties, super.aspectRatio);
 
   @override
   @override

--- a/packages/world_flags/lib/src/ui/painters/custom/btn_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/btn_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Bhutan flag.
 final class BtnPainter extends CustomElementsPainter {
   /// Creates a new instance of [BtnPainter].
-  const BtnPainter(super.properties, super.aspectRatio);
+  const BtnPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagBtnProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/clipped_triangle_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/clipped_triangle_painter.dart
@@ -8,7 +8,7 @@ import "../basic/elements_painter.dart";
 final class ClippedTrianglePainter extends ElementsPainter {
   /// Creates a [ClippedTrianglePainter] with the given [properties]
   /// and [aspectRatio].
-  const ClippedTrianglePainter(super.properties, super.aspectRatio);
+  const ClippedTrianglePainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/custom_diagonal_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/custom_diagonal_painter.dart
@@ -9,14 +9,14 @@ final class CustomDiagonalPainter extends MultiElementPainter {
   ///
   /// The [properties] parameter specifies the properties of the elements.
   /// The [aspectRatio] parameter specifies the aspect ratio of the elements.
-  const CustomDiagonalPainter.vertical(super.properties, super.aspectRatio)
+  const CustomDiagonalPainter.vertical(super._properties, super.aspectRatio)
     : _isHorizontal = false;
 
   /// Creates a [CustomDiagonalPainter] for horizontal diagonal elements.
   ///
   /// The [properties] parameter specifies the properties of the elements.
   /// The [aspectRatio] parameter specifies the aspect ratio of the elements.
-  const CustomDiagonalPainter.horizontal(super.properties, super.aspectRatio)
+  const CustomDiagonalPainter.horizontal(super._properties, super.aspectRatio)
     : _isHorizontal = true;
 
   final bool _isHorizontal;

--- a/packages/world_flags/lib/src/ui/painters/custom/cyp_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/cyp_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Cyprus flag.
 final class CypPainter extends CustomElementsPainter {
   /// Creates a new instance of [CypPainter].
-  const CypPainter(super.properties, super.aspectRatio);
+  const CypPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagCypProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/david_star_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/david_star_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Israel flag.
 final class DavidStarPainter extends CustomElementsPainter {
   /// Creates a new instance of [DavidStarPainter].
-  const DavidStarPainter(super.properties, super.aspectRatio);
+  const DavidStarPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds? paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/eagle_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/eagle_painter.dart
@@ -17,7 +17,7 @@ final class EaglePainter extends CustomElementsPainter {
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {
     MultiElementPainter(
       List.unmodifiable(properties.skip(1)),
-      aspectRatio, // ignore: unnecessary-trailing-comma, new dart format.
+      aspectRatio,
     ).paint(canvas, size);
 
     final adjustedSize = ratioAdjustedSize(size, minRatio: 2);

--- a/packages/world_flags/lib/src/ui/painters/custom/eagle_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/eagle_painter.dart
@@ -8,7 +8,7 @@ import "../multi_element_painter.dart";
 /// Painter for the simple eagle.
 final class EaglePainter extends CustomElementsPainter {
   /// Creates a new instance of [EaglePainter].
-  const EaglePainter(super.properties, super.aspectRatio);
+  const EaglePainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagAsmProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/eri_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/eri_painter.dart
@@ -8,7 +8,7 @@ import "../multi_element_painter.dart";
 /// Painter for the Eritrea flag.
 final class EriPainter extends CustomElementsPainter {
   /// Creates a new instance of [EriPainter].
-  const EriPainter(super.properties, super.aspectRatio);
+  const EriPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagEriProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/eri_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/eri_painter.dart
@@ -17,7 +17,7 @@ final class EriPainter extends CustomElementsPainter {
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {
     MultiElementPainter(
       List.unmodifiable(properties.skip(1)),
-      aspectRatio, // ignore: unnecessary-trailing-comma, new dart format.
+      aspectRatio,
     ).paint(canvas, size);
     final adjustedSize = ratioAdjustedSize(size);
     final center = calculateCenter(size);

--- a/packages/world_flags/lib/src/ui/painters/custom/esp_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/esp_painter.dart
@@ -9,7 +9,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Spain flag.
 final class EspPainter extends CustomElementsPainter {
   /// Creates a new instance of [EspPainter].
-  const EspPainter(super.properties, super.aspectRatio);
+  const EspPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagEspProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/geo_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/geo_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Georgia flag.
 final class GeoPainter extends MultiElementPainter {
   /// Creates a new instance of [GeoPainter].
-  const GeoPainter(super.properties, super.aspectRatio);
+  const GeoPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds? paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/ggy_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/ggy_painter.dart
@@ -13,7 +13,7 @@ import "../basic/custom_elements_painter.dart";
 /// 2. Yellow flared cross with triangular ends centered within the red cross.
 final class GgyPainter extends CustomElementsPainter {
   /// Creates a painter for the Guernsey flag.
-  const GgyPainter(super.properties, super.aspectRatio);
+  const GgyPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/half_ellipse_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/half_ellipse_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the half ellipse element.
 final class HalfEllipsePainter extends MultiElementPainter {
   /// Creates a new instance of [HalfEllipsePainter].
-  const HalfEllipsePainter(super.properties, super.aspectRatio);
+  const HalfEllipsePainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/hkg_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/hkg_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Hong Kong flag.
 final class HkgPainter extends CustomElementsPainter {
   /// Creates a new instance of [HkgPainter].
-  const HkgPainter(super.properties, super.aspectRatio);
+  const HkgPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagHkgProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/hrv_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/hrv_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Croatia flag.
 final class HrvPainter extends CustomElementsPainter {
   /// Creates a new instance of [HrvPainter].
-  const HrvPainter(super.properties, super.aspectRatio);
+  const HrvPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagHrvProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/imn_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/imn_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Isle of Man flag.
 final class ImnPainter extends CustomElementsPainter {
   /// Creates a new instance of [ImnPainter].
-  const ImnPainter(super.properties, super.aspectRatio);
+  const ImnPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagImnProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/irn_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/irn_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Iran flag.
 final class IrnPainter extends MultiElementPainter {
   /// Creates a new instance of [IrnPainter].
-  const IrnPainter(super.properties, super.aspectRatio);
+  const IrnPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagIrnProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/irq_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/irq_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Iraq flag.
 final class IrqPainter extends CustomElementsPainter {
   /// Creates a new instance of [IrqPainter].
-  const IrqPainter(super.properties, super.aspectRatio);
+  const IrqPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagIrqProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/kaz_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/kaz_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Kazakhstan flag.
 final class KazPainter extends MultiElementPainter {
   /// Creates a new instance of [KazPainter].
-  const KazPainter(super.properties, super.aspectRatio);
+  const KazPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagKazProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/ken_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/ken_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Kenya flag.
 final class KenPainter extends CustomElementsPainter {
   /// Creates a new instance of [KenPainter].
-  const KenPainter(super.properties, super.aspectRatio);
+  const KenPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagKenProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/khm_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/khm_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Cambodia flag.
 final class KhmPainter extends CustomElementsPainter {
   /// Creates a new instance of [KhmPainter].
-  const KhmPainter(super.properties, super.aspectRatio);
+  const KhmPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagKhmProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/kosovo_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/kosovo_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Kosovo region.
 final class KosovoPainter extends MultiElementPainter {
   /// Creates a new instance of [KosovoPainter].
-  const KosovoPainter(super.properties, super.aspectRatio);
+  const KosovoPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/lbn_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/lbn_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Lebanon flag.
 final class LbnPainter extends CustomElementsPainter {
   /// Creates a new instance of [LbnPainter].
-  const LbnPainter(super.properties, super.aspectRatio);
+  const LbnPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagLbnProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/lie_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/lie_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Liechtenstein flag.
 final class LiePainter extends CustomElementsPainter {
   /// Creates a new instance of [LiePainter].
-  const LiePainter(super.properties, super.aspectRatio);
+  const LiePainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagLieProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/lka_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/lka_painter.dart
@@ -17,7 +17,7 @@ final class LkaPainter extends CustomElementsPainter {
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {
     MultiElementPainter(
       List.unmodifiable(properties.skip(1)),
-      aspectRatio, // ignore: unnecessary-trailing-comma, new dart format.
+      aspectRatio,
     ).paint(canvas, size);
 
     final adjustedSize = ratioAdjustedSize(size);

--- a/packages/world_flags/lib/src/ui/painters/custom/lka_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/lka_painter.dart
@@ -8,7 +8,7 @@ import "../multi_element_painter.dart";
 /// Painter for the Sri Lanka flag.
 final class LkaPainter extends CustomElementsPainter {
   /// Creates a new instance of [LkaPainter].
-  const LkaPainter(super.properties, super.aspectRatio);
+  const LkaPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagLkaProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/lso_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/lso_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Lesotho flag.
 final class LsoPainter extends CustomElementsPainter {
   /// Creates a new instance of [LsoPainter].
-  const LsoPainter(super.properties, super.aspectRatio);
+  const LsoPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagLsoProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/mac_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/mac_painter.dart
@@ -8,7 +8,7 @@ import "../common/star_painter.dart";
 /// Painter for the Macau flag.
 final class MacPainter extends CustomElementsPainter {
   /// Creates a new instance of [MacPainter].
-  const MacPainter(super.properties, super.aspectRatio);
+  const MacPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagMacProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/maple_leaf_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/maple_leaf_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Canada flag.
 final class MapleLeafPainter extends CustomElementsPainter {
   /// Creates a new instance of [MapleLeafPainter].
-  const MapleLeafPainter(super.properties, super.aspectRatio);
+  const MapleLeafPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagCanProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/mhl_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/mhl_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Marshall Islands flag.
 final class MhlPainter extends MultiElementPainter {
   /// Creates a new instance of [MhlPainter].
-  const MhlPainter(super.properties, super.aspectRatio);
+  const MhlPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/mkd_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/mkd_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the North Macedonia flag.
 final class MkdPainter extends MultiElementPainter {
   /// Creates a new instance of [MkdPainter].
-  const MkdPainter(super.properties, super.aspectRatio);
+  const MkdPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds? paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/mne_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/mne_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Montenegro flag.
 final class MnePainter extends MultiElementPainter {
   /// Creates a new instance of [MnePainter].
-  const MnePainter(super.properties, super.aspectRatio);
+  const MnePainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagMneProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/npl_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/npl_painter.dart
@@ -7,7 +7,7 @@ import "../multi_element_painter.dart";
 /// Painter for the Nepal flag.
 final class NplPainter extends CustomElementsPainter {
   /// Creates a new instance of [NplPainter].
-  const NplPainter(super.properties, super.aspectRatio);
+  const NplPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds? paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/pine_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/pine_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Norfolk Island flag.
 final class PinePainter extends CustomElementsPainter {
   /// Creates a new instance of [PinePainter].
-  const PinePainter(super.properties, super.aspectRatio);
+  const PinePainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagNfkProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/png_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/png_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Papua New Guinea flag.
 final class PngPainter extends MultiElementPainter {
   /// Creates a new instance of [PngPainter].
-  const PngPainter(super.properties, super.aspectRatio);
+  const PngPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagPngProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/prt_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/prt_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Portugal flag.
 final class PrtPainter extends CustomElementsPainter {
   /// Creates a new instance of [PrtPainter].
-  const PrtPainter(super.properties, super.aspectRatio);
+  const PrtPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagPrtProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/pyf_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/pyf_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the French Polynesia flag.
 final class PyfPainter extends MultiElementPainter {
   /// Creates a new instance of [PyfPainter].
-  const PyfPainter(super.properties, super.aspectRatio);
+  const PyfPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/shahada_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/shahada_painter.dart
@@ -10,11 +10,11 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Saudi Arabia and Afghanistan flag.
 final class ShahadaPainter extends CustomElementsPainter {
   /// Creates a new instance of [ShahadaPainter] for the Saudi Arabia flag.
-  const ShahadaPainter.sau(super.properties, super.aspectRatio)
+  const ShahadaPainter.sau(super._properties, super.aspectRatio)
     : _hasSabre = true;
 
   /// Creates a new instance of [ShahadaPainter] for the Afghanistan flag.
-  const ShahadaPainter.afg(super.properties, super.aspectRatio)
+  const ShahadaPainter.afg(super._properties, super.aspectRatio)
     : _hasSabre = false;
 
   final bool _hasSabre;

--- a/packages/world_flags/lib/src/ui/painters/custom/simple_bird_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/simple_bird_painter.dart
@@ -3,11 +3,11 @@ part of "../multi_element_painter.dart";
 /// Painter for the simple bird.
 final class SimpleBirdPainter extends MultiElementPainter {
   /// Creates a new instance of [SimpleBirdPainter] for Egypt flag.
-  const SimpleBirdPainter.egy(super.properties, super.aspectRatio)
+  const SimpleBirdPainter.egy(super._properties, super.aspectRatio)
     : _originalAspectRatio = FlagConstants.defaultAspectRatio;
 
   /// Creates a new instance of [SimpleBirdPainter] for Moldova flag.
-  const SimpleBirdPainter.mda(super.properties, super.aspectRatio)
+  const SimpleBirdPainter.mda(super._properties, super.aspectRatio)
     : _originalAspectRatio = 2;
 
   final double _originalAspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/simple_shield_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/simple_shield_painter.dart
@@ -10,7 +10,7 @@ final class SimpleShieldPainter extends MultiElementPainter {
   /// The [properties] parameter specifies the properties of the shield. The
   /// [aspectRatio] parameter specifies the aspect ratio of the shield.
   const SimpleShieldPainter.outlinedWithDividers(
-    super.properties,
+    super._properties,
     super.aspectRatio,
   ) : _showDividers = true,
       _showOutline = true;
@@ -20,7 +20,7 @@ final class SimpleShieldPainter extends MultiElementPainter {
   /// The [properties] parameter specifies the properties of the shield. The
   /// [aspectRatio] parameter specifies the aspect ratio of the shield.
   const SimpleShieldPainter.outlinedWithoutDividers(
-    super.properties,
+    super._properties,
     super.aspectRatio,
   ) : _showDividers = false,
       _showOutline = true;
@@ -30,7 +30,7 @@ final class SimpleShieldPainter extends MultiElementPainter {
   ///
   /// The [properties] parameter specifies the properties of the shield. The
   /// [aspectRatio] parameter specifies the aspect ratio of the shield.
-  const SimpleShieldPainter.withDividers(super.properties, super.aspectRatio)
+  const SimpleShieldPainter.withDividers(super._properties, super.aspectRatio)
     : _showDividers = true,
       _showOutline = false;
 
@@ -39,8 +39,10 @@ final class SimpleShieldPainter extends MultiElementPainter {
   ///
   /// The [properties] parameter specifies the properties of the shield. The
   /// [aspectRatio] parameter specifies the aspect ratio of the shield.
-  const SimpleShieldPainter.withoutDividers(super.properties, super.aspectRatio)
-    : _showDividers = false,
+  const SimpleShieldPainter.withoutDividers(
+    super._properties,
+    super.aspectRatio,
+  ) : _showDividers = false,
       _showOutline = false;
 
   final bool _showDividers;

--- a/packages/world_flags/lib/src/ui/painters/custom/smr_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/smr_painter.dart
@@ -9,7 +9,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the San Marino flag.
 final class SmrPainter extends CustomElementsPainter {
   /// Creates a new instance of [SmrPainter].
-  const SmrPainter(super.properties, super.aspectRatio);
+  const SmrPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagSmrProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/srb_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/srb_painter.dart
@@ -9,7 +9,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Serbia flag.
 final class SrbPainter extends CustomElementsPainter {
   /// Creates a new instance of [SrbPainter].
-  const SrbPainter(super.properties, super.aspectRatio);
+  const SrbPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagSrbProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/svk_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/svk_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Slovakia flag.
 final class SvkPainter extends CustomElementsPainter {
   /// Creates a new instance of [SvkPainter].
-  const SvkPainter(super.properties, super.aspectRatio);
+  const SvkPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagSvkProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/svn_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/svn_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Slovenia flag.
 final class SvnPainter extends CustomElementsPainter {
   /// Creates a new instance of [SvnPainter].
-  const SvnPainter(super.properties, super.aspectRatio);
+  const SvnPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagSvnProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/syc_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/syc_painter.dart
@@ -6,7 +6,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Seychelles flag.
 final class SycPainter extends CustomElementsPainter {
   /// Creates a new instance of [SycPainter].
-  const SycPainter(super.properties, super.aspectRatio);
+  const SycPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/taegukgi_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/taegukgi_painter.dart
@@ -8,7 +8,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the South Korea flag.
 final class TaegukgiPainter extends CustomElementsPainter {
   /// Creates a new instance of [TaegukgiPainter].
-  const TaegukgiPainter(super.properties, super.aspectRatio);
+  const TaegukgiPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagKorProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/tjk_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/tjk_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Tajikistan flag.
 final class TjkPainter extends MultiElementPainter {
   /// Creates a new instance of [TjkPainter].
-  const TjkPainter(super.properties, super.aspectRatio);
+  const TjkPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagTjkProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/tkl_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/tkl_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Tokelau flag.
 final class TklPainter extends MultiElementPainter {
   /// Creates a new instance of [TklPainter].
-  const TklPainter(super.properties, super.aspectRatio);
+  const TklPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/tkm_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/tkm_painter.dart
@@ -5,7 +5,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Turkmenistan flag.
 final class TkmPainter extends MultiElementPainter {
   /// Creates a new instance of [TkmPainter].
-  const TkmPainter(super.properties, super.aspectRatio);
+  const TkmPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/tto_line_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/tto_line_painter.dart
@@ -6,7 +6,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Trinidad and Tobago flag.
 final class TtoLinePainter extends CustomElementsPainter {
   /// Creates a new instance of [TtoLinePainter].
-  const TtoLinePainter(super.properties, super.aspectRatio);
+  const TtoLinePainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/uga_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/uga_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Uganda flag.
 final class UgaPainter extends MultiElementPainter {
   /// Creates a new instance of [UgaPainter].
-  const UgaPainter(super.properties, super.aspectRatio);
+  const UgaPainter(super._properties, super.aspectRatio);
 
   @override
   FlagParentBounds paintFlagElements(Canvas canvas, Size size) {

--- a/packages/world_flags/lib/src/ui/painters/custom/union_jack_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/union_jack_painter.dart
@@ -12,7 +12,7 @@ final class UnionJackPainter extends SimpleShieldPainter {
   ///
   /// The [properties] parameter specifies the properties of the shield. The
   /// [aspectRatio] parameter specifies the aspect ratio of the shield.
-  const UnionJackPainter.half(super.properties, super.aspectRatio)
+  const UnionJackPainter.half(super._properties, super.aspectRatio)
     : _isFull = false,
       super.outlinedWithoutDividers();
 
@@ -21,15 +21,17 @@ final class UnionJackPainter extends SimpleShieldPainter {
   ///
   /// The [properties] parameter specifies the properties of the shield. The
   /// [aspectRatio] parameter specifies the aspect ratio of the shield.
-  const UnionJackPainter.halfWithoutOutline(super.properties, super.aspectRatio)
-    : _isFull = false,
+  const UnionJackPainter.halfWithoutOutline(
+    super._properties,
+    super.aspectRatio,
+  ) : _isFull = false,
       super.withoutDividers();
 
   /// Creates a [UnionJackPainter] with a half Union Jack with dividers.
   ///
   /// The [properties] parameter specifies the properties of the shield. The
   /// [aspectRatio] parameter specifies the aspect ratio of the shield.
-  const UnionJackPainter.halfWithDividers(super.properties, super.aspectRatio)
+  const UnionJackPainter.halfWithDividers(super._properties, super.aspectRatio)
     : _isFull = false,
       super.withDividers();
 
@@ -37,7 +39,7 @@ final class UnionJackPainter extends SimpleShieldPainter {
   ///
   /// The [properties] parameter specifies the properties of the shield. The
   /// [aspectRatio] parameter specifies the aspect ratio of the shield.
-  const UnionJackPainter.full(super.properties, super.aspectRatio)
+  const UnionJackPainter.full(super._properties, super.aspectRatio)
     : _isFull = true,
       super.withoutDividers();
 

--- a/packages/world_flags/lib/src/ui/painters/custom/usa_stars_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/usa_stars_painter.dart
@@ -5,7 +5,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the USA flag.
 final class UsaStarsPainter extends MultiElementPainter {
   /// Creates a new instance of [UsaStarsPainter].
-  const UsaStarsPainter(super.properties, super.aspectRatio);
+  const UsaStarsPainter(super._properties, super.aspectRatio);
 
   /// Count of star points.
   static const _points = 5;

--- a/packages/world_flags/lib/src/ui/painters/custom/vat_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/vat_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Vatican City flag.
 final class VatPainter extends CustomElementsPainter {
   /// Creates a new instance of [VatPainter].
-  const VatPainter(super.properties, super.aspectRatio);
+  const VatPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagVatProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/vct_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/vct_painter.dart
@@ -7,7 +7,7 @@ import "../basic/custom_elements_painter.dart";
 /// Painter for the Saint Vincent and the Grenadines flag.
 final class VctPainter extends CustomElementsPainter {
   /// Creates a new instance of [VctPainter].
-  const VctPainter(super.properties, super.aspectRatio);
+  const VctPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagVctProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/vir_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/vir_painter.dart
@@ -8,7 +8,7 @@ import "../multi_element_painter.dart";
 /// Painter for the U.S. Virgin Islands flag.
 final class VirPainter extends CustomElementsPainter {
   /// Creates a new instance of [VirPainter].
-  const VirPainter(super.properties, super.aspectRatio);
+  const VirPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagVirProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/custom/zmb_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/custom/zmb_painter.dart
@@ -3,7 +3,7 @@ part of "../multi_element_painter.dart";
 /// Painter for the Zambia flag.
 final class ZmbPainter extends MultiElementPainter {
   /// Creates a new instance of [ZmbPainter].
-  const ZmbPainter(super.properties, super.aspectRatio);
+  const ZmbPainter(super._properties, super.aspectRatio);
 
   @override
   double get originalAspectRatio => flagZmbProperties.aspectRatio;

--- a/packages/world_flags/lib/src/ui/painters/multi_element_painter.dart
+++ b/packages/world_flags/lib/src/ui/painters/multi_element_painter.dart
@@ -47,7 +47,7 @@ final class MultiElementPainter extends CustomElementsPainter {
   ///
   /// - [properties]: The properties of the elements to be painted.
   /// - [aspectRatio]: The aspect ratio of the flag.
-  const MultiElementPainter(super.properties, super.aspectRatio);
+  const MultiElementPainter(super._properties, super.aspectRatio);
 
   /// Paints the custom flag elements on the given canvas and size.
   ///

--- a/packages/world_flags/pubspec.yaml
+++ b/packages/world_flags/pubspec.yaml
@@ -1,4 +1,4 @@
-version: 3.2.0
+version: 3.3.0
 name: world_flags
 description: The first and only collection of declaratively defined world flags. No assets.
 maintainer: Roman Cinis

--- a/packages/world_flags/pubspec.yaml
+++ b/packages/world_flags/pubspec.yaml
@@ -29,7 +29,7 @@ platforms:
   windows:
 
 environment:
-  sdk: ^3.10.8
+  sdk: ^3.12.0
 
 dependencies:
   flutter:

--- a/packages/world_flags/test/src/ui/flags/iso/dual_flag_test.dart
+++ b/packages/world_flags/test/src/ui/flags/iso/dual_flag_test.dart
@@ -3,6 +3,7 @@ import "package:flutter/material.dart" show MaterialApp, Scaffold;
 import "package:flutter/widgets.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:sealed_countries/sealed_countries.dart";
+import "package:world_flags/src/helpers/extensions/box_decoration_extension.dart";
 import "package:world_flags/src/model/colors_properties.dart";
 import "package:world_flags/src/model/flag_properties.dart";
 import "package:world_flags/src/ui/flags/basic_flag.dart";
@@ -55,6 +56,26 @@ void main() => group("$DualFlag", () {
     await tester.pumpWidget(const MaterialApp(home: flag));
 
     expect(find.byType(ClipPath), findsOneWidget);
+  });
+
+  testWidgets("applies decoration to both flags when decoration is provided", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: DualFlag(
+          item,
+          primeMap,
+          alternativeMap: alternativeMap,
+          decoration: BoxDecoration(shape: BoxShape.circle),
+        ),
+      ),
+    );
+
+    final basicFlags = tester.widgetList<BasicFlag>(find.byType(BasicFlag));
+    expect(basicFlags.firstOrNull?.decoration.isCircle, isTrue);
+    expect(basicFlags.lastOrNull?.decoration.isCircle, isTrue);
+    expect(basicFlags, hasLength(2));
   });
 
   testWidgets("passes clipBehavior to ClipPath", (tester) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: "direct dev"
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: "direct dev"
     description:
       name: dart_code_metrics_presets
-      sha256: "4c5296523e16bfd0a75905a87ff722f53f759e30f9c20195f1dc69859e392919"
+      sha256: c2b890695e732329c79085194c6fc815a20acf44e553fad6c72f75bf3ae203cf
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.32.0"
   dart_style:
     dependency: transitive
     description:
@@ -779,5 +779,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0 <4.0.0"
+  dart: ">=3.12.2 <4.0.0"
+  flutter: ">=3.44.2 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
   - iso
 
 environment:
-  sdk: ^3.12.0
+  sdk: ^3.12.2
 
 workspace:
   - tools # Command-line tools for public packages.
@@ -35,7 +35,7 @@ workspace:
 
 dev_dependencies:
   benchmark_harness: ^2.4.0 # From Google. Defines top level dependency constraint.
-  coverage: ^1.15.0 # From Google. Defines top level dependency constraint.
-  dart_code_metrics_presets: ^2.31.0 # DCM. Defines top level dependency constraint.
+  coverage: ^1.15.1 # From Google. Defines top level dependency constraint.
+  dart_code_metrics_presets: ^2.32.0 # DCM. Defines top level dependency constraint.
   lints: ^6.1.0 # From Google. Defines top level dependency constraint.
   test: ^1.31.0 # From Google. Defines top level dependency constraint.


### PR DESCRIPTION
## Type of Change

<!--- Please put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] 🧪 Tests
- [x] 📝 Documentation
- [ ] ⚙️ CI/CD or GitHub Workflow configuration change
- [x] 📦 Chore or dependencies update

## Checks

Please look at the following checklist to ensure that your PR can be accepted quickly:

<!--- Please put an `x` in all the boxes that apply: -->

- [x] Data comes from open-source resources with the MIT License (if presented).
- [x] New code is documented and the data source is referenced (if presented).
- [x] Existing tests are up to date with these changes.
- [x] New code is fully tested (if presented).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VM “deeply immutable” optimizations for several value types used across countries and flags.

* **Bug Fixes**
  * Fixed split-flag decoration so provided styling is applied to both parts consistently.
  * Improved random selection reliability in test utilities.

* **Chores**
  * Updated package versions and SDK/environment constraints.
  * Expanded analyzer/lint configurations and added deprecation notices to discourage subclassing of upcoming-to-be-final types.

* **Tests**
  * Added coverage for verifying shared decoration behavior on split flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->