### PR TITLE
refactor(ci): update deploy permissions and steps for gh pages

### DIFF
--- a/.github/workflows/deploy_example_web.yaml
+++ b/.github/workflows/deploy_example_web.yaml
@@ -9,7 +9,9 @@ on:
       - ".github/workflows/deploy_example_web.yaml"
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}
@@ -20,6 +22,9 @@ jobs:
     name: 🚀 Deploy example website
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: 📚 Git checkout
         uses: actions/checkout@v7.0.0
@@ -38,10 +43,11 @@ jobs:
         working-directory: packages/world_countries/example
         run: flutter build web --release --base-href=/sealed_world/ --wasm
 
-      - name: 🛫 Deploy the website to GH Pages
-        uses: s0/git-publish-subdir-action@v2.6.0
-        env:
-          REPO: self
-          BRANCH: gh-pages
-          FOLDER: packages/world_countries/example/build/web
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 📤 Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v5.0.0
+        with:
+          path: packages/world_countries/example/build/web
+
+      - name: 🛫 Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ android/
 json/
 **/example/android/app/.cxx/*
 **/example/benchmarks/*.json
+**/example/android/.kotlin/sessions/**

--- a/packages/world_countries/example/android/app/build.gradle.kts
+++ b/packages/world_countries/example/android/app/build.gradle.kts
@@ -152,11 +152,12 @@ val augmentOutputMetadataProfile by tasks.registering {
 }
 
 // Bind finalizer when assembleProfile is created
-tasks.whenTaskAdded {
-    if (this.path == ":app:assembleProfile") {
-        this.finalizedBy(augmentOutputMetadataProfile)
+tasks.configureEach {
+    if (name == "assembleProfile") {
+        finalizedBy(augmentOutputMetadataProfile)
     }
 }
+
 
 // Fallback: finalize any Flutter-side profile build proxies
 val postAssembleProfileCheck by tasks.registering {
@@ -172,5 +173,9 @@ val postAssembleProfileCheck by tasks.registering {
     }
 }
 
-tasks.matching { it.name.contains("compileFlutterBuild") && it.name.endsWith("Profile") }
-    .configureEach { finalizedBy(postAssembleProfileCheck) }
+tasks.configureEach {
+    if (name.contains("compileFlutterBuild") && name.endsWith("Profile")) {
+        finalizedBy(postAssembleProfileCheck)
+    }
+}
+

--- a/packages/world_countries/example/pubspec.yaml
+++ b/packages/world_countries/example/pubspec.yaml
@@ -7,7 +7,7 @@ resolution: workspace
 
 environment:
   sdk: ^3.12.2
-  flutter: ^3.44.4
+  flutter: ^3.44.5
 
 dependencies:
   flutter:

--- a/packages/world_flags/example/android/app/build.gradle.kts
+++ b/packages/world_flags/example/android/app/build.gradle.kts
@@ -152,11 +152,12 @@ val augmentOutputMetadataProfile by tasks.registering {
 }
 
 // Bind finalizer when assembleProfile is created
-tasks.whenTaskAdded {
-    if (this.path == ":app:assembleProfile") {
-        this.finalizedBy(augmentOutputMetadataProfile)
+tasks.configureEach {
+    if (name == "assembleProfile") {
+        finalizedBy(augmentOutputMetadataProfile)
     }
 }
+
 
 // Fallback: finalize any Flutter-side profile build proxies
 val postAssembleProfileCheck by tasks.registering {
@@ -172,5 +173,9 @@ val postAssembleProfileCheck by tasks.registering {
     }
 }
 
-tasks.matching { it.name.contains("compileFlutterBuild") && it.name.endsWith("Profile") }
-    .configureEach { finalizedBy(postAssembleProfileCheck) }
+tasks.configureEach {
+    if (name.contains("compileFlutterBuild") && name.endsWith("Profile")) {
+        finalizedBy(postAssembleProfileCheck)
+    }
+}
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "99.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "12.1.0"
   archive:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   benchmark_harness:
     dependency: "direct dev"
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3"
+      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.6"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9"
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.4"
+    version: "8.12.6"
   change_case:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.7"
+    version: "3.1.8"
   dartx:
     dependency: transitive
     description:
@@ -377,10 +377,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -702,10 +702,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "5a88dd14c0954a5398af544651c7fb51b457a2a556949bfb25369b210ef73a74"
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:
@@ -718,10 +718,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
@@ -780,4 +780,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.2 <4.0.0"
-  flutter: ">=3.44.2 <4.0.0"
+  flutter: ">=3.44.5 <4.0.0"

--- a/tools/pubspec.yaml
+++ b/tools/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.12.0
+  sdk: ^3.12.2
 
 dependencies:
   args: ^2.7.0


### PR DESCRIPTION

- Changed permissions for contents to read.
- Added environment name for GitHub Pages deployment.
- Updated deployment steps to use actions/upload-pages-artifact and actions/deploy-pages.

## Type of Change

<!--- Please put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [x] ⚙️ CI/CD or GitHub Workflow configuration change
- [x] 📦 Chore or dependencies update

## Checks

Please look at the following checklist to ensure that your PR can be accepted quickly:

<!--- Please put an `x` in all the boxes that apply: -->

- [x] Data comes from open-source resources with the MIT License (if presented).
- [x] New code is documented and the data source is referenced (if presented).
- [x] Existing tests are up to date with these changes.
- [x] New code is fully tested (if presented).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated web deployment to use the platform’s built-in Pages flow and now captures the live site URL after deployment.

* **Bug Fixes**
  * Improved Android profile build handling for example apps so post-build checks run more reliably.
  * Expanded ignored local session files to reduce accidental repository noise.

* **Chores**
  * Bumped supported SDK versions for the example app and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->